### PR TITLE
Inventory now uses the aether sprite, so that it has the slot icons.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.14.19-babric.3-bta
 terrain_api_version=1.4.2-7.1
 halplibe_version=3.1.1
 dragonfly_version=1.3.1-7.1
-accessoryapi_version=1.0.0
+accessoryapi_version=1.0.1
 
 # Mod
 mod_version=1.0.0-7.1

--- a/src/main/java/bta/aether/mixin/SlotArmorMixin.java
+++ b/src/main/java/bta/aether/mixin/SlotArmorMixin.java
@@ -1,0 +1,17 @@
+package bta.aether.mixin;
+
+import net.minecraft.core.player.inventory.slot.SlotArmor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = SlotArmor.class, remap = false)
+public abstract class SlotArmorMixin {
+
+    // cancel the bta armor icon from appearing, since the aether has its own that are on the inventory.png
+    @Inject(method = "getBackgroundIconIndex",at=@At("HEAD"),cancellable = true)
+    public void getBackgroundIconIndex(CallbackInfoReturnable<Integer> cir) {
+        cir.setReturnValue(-1);
+    }
+}

--- a/src/main/resources/aether.mixins.json
+++ b/src/main/resources/aether.mixins.json
@@ -15,6 +15,7 @@
     "accessors.ItemToolSwordAccessor"
   ],
   "client": [
+    "SlotArmorMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fixed this within my library by just detecting if aether is installed :shrug:

Also added a mixin to remove the armor slot icons, which would interfere with the aether ones