### PR TITLE
Regen Stone Patch

### DIFF
--- a/src/main/java/bta/aether/item/Accessories/ItemAccessoryInvisibilityCloak.java
+++ b/src/main/java/bta/aether/item/Accessories/ItemAccessoryInvisibilityCloak.java
@@ -11,11 +11,6 @@ public class ItemAccessoryInvisibilityCloak extends ItemAccessoryCape {
     }
 
     @Override
-    public String[] getAccessoryTypes(ItemStack itemStack) {
-        return new String[]{"cape"};
-    }
-
-    @Override
     public void onAccessoryAdded(EntityPlayer player, ItemStack accessory) {
         ((IAetherAccessories)player).aether$setInvisible(true);
     }

--- a/src/main/java/bta/aether/item/Accessories/ItemAccessoryRegenStone.java
+++ b/src/main/java/bta/aether/item/Accessories/ItemAccessoryRegenStone.java
@@ -32,7 +32,8 @@ public class ItemAccessoryRegenStone extends ItemAccessoryMisc implements Tickab
             stack.setMetadata(0);
             // only heal if it's the first equipped, since in the OG mod effect doesn't stack.
             // also don't heal when player has max health, since that causes hearts flash
-            if (slot == AccessoryHelper.firstSlotWithAccessory(player, stack.getItem()) && player.getHealth() < 20) {
+            // Not sure if this is supposed to heal life crystal hearts, so I added that. - Cookie
+            if (slot == AccessoryHelper.firstSlotWithAccessory(player, stack.getItem()) && player.getHealth() < player.getMaxHealth()) {
                 player.heal(1);
             }
         }

--- a/src/main/java/bta/aether/item/Accessories/base/ItemAccessoryCape.java
+++ b/src/main/java/bta/aether/item/Accessories/base/ItemAccessoryCape.java
@@ -5,7 +5,7 @@ import bta.aether.item.TexturePath;
 import net.minecraft.core.item.ItemStack;
 
 public class ItemAccessoryCape extends ItemToolAccessory implements TexturePath {
-    private String texturePath;
+    private final String texturePath;
 
     public ItemAccessoryCape(String name, int id, String texturePath) {
         super(name, id);


### PR DESCRIPTION
* Removed redundant accessory type initializer from Invisibility Cloak
* Fixed the RegenStone not healing extra hearts