### PR TITLE
Fixed BTA title case in description string

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,7 +4,7 @@
   "version": "0.2.0",
 
   "name": "Aether",
-  "description": "The legendary dimension is finally here for Better Than Adventure!",
+  "description": "The legendary dimension is finally here for Better than Adventure!",
   "authors": [
     "LukeisStuff",
     "jonkadelic",


### PR DESCRIPTION
Changed description string from:
"The legendary dimension is finally here for Better Than Adventure!"
to:
"The legendary dimension is finally here for Better than Adventure!"