### PR TITLE
Hide mimic from BTWaila

### DIFF
--- a/src/main/java/teamport/aether/AetherConfig.java
+++ b/src/main/java/teamport/aether/AetherConfig.java
@@ -34,7 +34,7 @@ public class AetherConfig {
 
 
     static void Setup() {
-        int dimensionDefault = 3;
+        int dimensionDefault = 3; // so it wont bug me for testing
         int extraHealthDefault = 20;
         float quicksoilCapDefault = 1.325F;
 

--- a/src/main/java/teamport/aether/AetherMod.java
+++ b/src/main/java/teamport/aether/AetherMod.java
@@ -52,7 +52,7 @@ public class AetherMod implements GameStartEntrypoint, ModInitializer {
     public static MobFireflyCluster.FireflyColor SILVER;
 
     // hide the mimic description
-    public static final boolean BWAILA = FabricLoader.getInstance().isModLoaded("btwaila");
+    public static final boolean BTWAILA = FabricLoader.getInstance().isModLoaded("btwaila");
     // for slots
     public static final byte ARMOR_START_INDEX = 41;
 

--- a/src/main/java/teamport/aether/AetherMod.java
+++ b/src/main/java/teamport/aether/AetherMod.java
@@ -1,6 +1,7 @@
 package teamport.aether;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.block.Blocks;
 import net.minecraft.core.crafting.LookupFuelFurnace;
 import net.minecraft.core.entity.EntityPainting;
@@ -46,15 +47,19 @@ import static net.minecraft.core.entity.animal.MobFireflyCluster.FireflyColor.re
 public class AetherMod implements GameStartEntrypoint, ModInitializer {
     public static final String MOD_ID = "aether";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+    public static String versionString = FabricLoader.getInstance().getModContainer(MOD_ID).get().getMetadata().getVersion().getFriendlyString();
+    public static String state = "alpha";
     public static MobFireflyCluster.FireflyColor SILVER;
 
+    // hide the mimic description
+    public static final boolean BWAILA = FabricLoader.getInstance().isModLoaded("btwaila");
     // for slots
     public static final byte ARMOR_START_INDEX = 41;
 
     @Override
     public void onInitialize() {
-        LOGGER.info("Aether initialized. Welcome to a hostile paradise.");
-
+        LOGGER.info("Aether initialized.");
+        LOGGER.info(" Welcome to a hostile paradise. Version {} {}", state , versionString);
         NetworkHandler.registerNetworkMessage(SunspiritDeathNetworkMessage::new);
     }
 

--- a/src/main/java/teamport/aether/blocks/BlockLogicChestMimic.java
+++ b/src/main/java/teamport/aether/blocks/BlockLogicChestMimic.java
@@ -22,7 +22,7 @@ import teamport.aether.tile.TileEntityMimic;
 import java.util.ArrayList;
 import java.util.List;
 
-import static teamport.aether.AetherMod.BWAILA;
+import static teamport.aether.AetherMod.BTWAILA;
 
 public class BlockLogicChestMimic extends BlockLogicRotatable {
     private double dx;
@@ -36,7 +36,7 @@ public class BlockLogicChestMimic extends BlockLogicRotatable {
 
     @Override
     public String getLanguageKey(int meta) {
-        if (BWAILA) {
+        if (BTWAILA) {
             // hides the mimic name and description
             return AetherBlocks.CHEST_PLANKS_SKYROOT.getKey();
         }
@@ -105,7 +105,7 @@ public class BlockLogicChestMimic extends BlockLogicRotatable {
             moveToSafe(world, mimic, x, y, z, player.xRot - 180, player.xRot - 180);
             world.entityJoinedWorld(mimic);
         }
-        if (player.tickCount % 10 == 0 && !BWAILA) {
+        if (player.tickCount % 10 == 0 && !BTWAILA) {
             player.sendMessage("Thank you dark souls.");
         }
         world.playSoundEffect(player, SoundCategory.ENTITY_SOUNDS, x + 0.5, y + 0.5, z + 0.5, "random.door_open", 1.0f, 0.5f);

--- a/src/main/java/teamport/aether/blocks/BlockLogicChestMimic.java
+++ b/src/main/java/teamport/aether/blocks/BlockLogicChestMimic.java
@@ -1,10 +1,11 @@
 package teamport.aether.blocks;
 
 import net.minecraft.core.block.Block;
-import net.minecraft.core.block.BlockLogicChest;
+import net.minecraft.core.block.BlockLogicRotatable;
 import net.minecraft.core.block.entity.TileEntity;
 import net.minecraft.core.block.entity.TileEntityActivator;
 import net.minecraft.core.block.material.Material;
+import net.minecraft.core.entity.Mob;
 import net.minecraft.core.entity.player.Player;
 import net.minecraft.core.enums.EnumDropCause;
 import net.minecraft.core.item.ItemStack;
@@ -16,14 +17,30 @@ import net.minecraft.core.world.World;
 import org.jetbrains.annotations.Nullable;
 import teamport.aether.AetherAchievements;
 import teamport.aether.entity.monster.mimic.MobMimic;
+import teamport.aether.tile.TileEntityMimic;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class BlockLogicChestMimic extends BlockLogicChest {
+import static teamport.aether.AetherMod.BWAILA;
+
+public class BlockLogicChestMimic extends BlockLogicRotatable {
+    private double dx;
+    private double dy;
+    private double dz;
 
     public BlockLogicChestMimic(Block<?> block) {
         super(block, Material.wood);
+        block.withEntity(TileEntityMimic::new);
+    }
+
+    @Override
+    public String getLanguageKey(int meta) {
+        if (BWAILA) {
+            // hides the mimic name and description
+            return AetherBlocks.CHEST_PLANKS_SKYROOT.getKey();
+        }
+        return super.getLanguageKey(meta);
     }
 
     public ItemStack @Nullable [] getBreakResult(World world, EnumDropCause dropCause, int x, int y, int z, int meta, TileEntity tileEntity) {
@@ -35,15 +52,16 @@ public class BlockLogicChestMimic extends BlockLogicChest {
                 MobMimic mimic = new MobMimic(world);
                 List<ItemStack> chestInv = getAndClearInventory(world, x, y, z);
                 mimic.setLoot(chestInv);
-                world.playSoundEffect(mimic, SoundCategory.ENTITY_SOUNDS,x + 0.5, y + 0.5, z + 0.5, "random.door_open", 1.0f, 0.5f);
+                world.playSoundEffect(mimic, SoundCategory.ENTITY_SOUNDS, x + 0.5, y + 0.5, z + 0.5, "random.door_open", 1.0f, 0.5f);
                 world.setBlockWithNotify(x, y, z, 0);
                 mimic.spawnInit();
                 Player player = world.getClosestPlayer(x, y, z, 16);
                 if (player != null) {
-                    mimic.absMoveTo(x + 0.5, y, z + 0.5, (player.yRot) - 180F, -player.xRot);
+                    moveToSafe(world, mimic, x, y, z, player.xRot - 180, player.xRot - 180);
                     player.triggerAchievement(AetherAchievements.ITS_A_TRAP);
+                } else {
+                    mimic.absMoveTo(x + 0.5, y, z + 0.5, mimic.yRot, mimic.xRot);
                 }
-                else mimic.absMoveTo(x + 0.5, y, z + 0.5, mimic.yRot, mimic.xRot);
                 world.spawnParticle("explode", x + 0.5, y + 1, z + 0.5, 0.0, 0.0, 0.0, 0);
                 world.entityJoinedWorld(mimic);
         }
@@ -51,12 +69,12 @@ public class BlockLogicChestMimic extends BlockLogicChest {
     }
 
     private List<ItemStack> getAndClearInventory(World world, int x, int y, int z) {
-        Container inv = getInventory(world, x, y, z);
+        Container inv = (Container) world.getTileEntity(x, y, z);
         if (inv == null) {
             return null;
         }
         List<ItemStack> stacks = new ArrayList<>();
-        for(int i = 0; i < inv.getContainerSize(); i++){
+        for (int i = 0; i < inv.getContainerSize(); i++) {
             stacks.add(inv.getItem(i));
             inv.setItem(i, null);
         }
@@ -64,15 +82,15 @@ public class BlockLogicChestMimic extends BlockLogicChest {
     }
 
     public void onActivatorInteract(World world, int x, int y, int z, TileEntityActivator activator, Direction direction) {
-        world.playSoundEffect(null, SoundCategory.ENTITY_SOUNDS,x + 0.5, y + 0.5, z + 0.5, "random.door_open", 1.0f, 0.5f);
         List<ItemStack> chestInv = getAndClearInventory(world, x, y, z);
-        world.setBlockWithNotify(x, y, z, 0);
         MobMimic mimic = new MobMimic(world);
         mimic.setLoot(chestInv);
         mimic.spawnInit();
-        mimic.absMoveTo(x + 0.5, y, z + 0.5, (mimic.yRot) - 180.0f, -(mimic.xRot));
-        world.spawnParticle("explode", x + 0.5, y + 1, z + 0.5, 0.0, 0.0, 0.0, 0);
+        moveToSafe(world, mimic, x, y, z, 0, 0);
         world.entityJoinedWorld(mimic);
+        world.setBlockWithNotify((int)Math.round(dx), (int)Math.round(dy), (int)Math.round(dz), 0);
+        world.playSoundEffect(null, SoundCategory.ENTITY_SOUNDS, dx, dy, dz, "random.door_open", 1.0f, 0.5f);
+        world.spawnParticle("explode", dx, dy, dz, 0.0, 0.0, 0.0, 0);
     }
 
     @Override
@@ -80,19 +98,60 @@ public class BlockLogicChestMimic extends BlockLogicChest {
         List<ItemStack> chestInv = getAndClearInventory(world, x, y, z);
         world.setBlockWithNotify(x, y, z, 0);
         if (!world.isClientSide) {
+            player.triggerAchievement(AetherAchievements.ITS_A_TRAP);
             MobMimic mimic = new MobMimic(world);
             mimic.setLoot(chestInv);
             mimic.spawnInit();
-            mimic.absMoveTo(x + 0.5, y, z + 0.5, (player.yRot) - 180.0f, -(player.xRot));
+            moveToSafe(world, mimic, x, y, z, player.xRot - 180, player.xRot - 180);
             world.entityJoinedWorld(mimic);
         }
+        if (player.tickCount % 10 == 0 && !BWAILA) {
+            player.sendMessage("Thank you dark souls.");
+        }
         world.playSoundEffect(player, SoundCategory.ENTITY_SOUNDS, x + 0.5, y + 0.5, z + 0.5, "random.door_open", 1.0f, 0.5f);
-
         world.spawnParticle("explode", x + 0.5, y + 1, z + 0.5, 0.0, 0.0, 0.0, 0);
-
         player.triggerAchievement(AetherAchievements.ITS_A_TRAP);
-
         return true;
+    }
+
+    // not sure if this is the correct place for these functions
+    public void moveToSafe(World world, Mob mob, int x, int y, int z, float yRot, float xRot) {
+        if (this.isSafe(world, x - 1, y, z)) {
+            mob.moveTo(x - 0.5F, y, z + 0.5F, yRot, xRot);
+            this.dx = x - 0.5F;
+            this.dy = y;
+            this.dz = z + 0.5F;
+            return;
+        }
+        if (this.isSafe(world, x + 1, y, z)) {
+            mob.moveTo(x + 1.5F, y, z + 0.5F, yRot, xRot);
+            this.dx = x + 1.5F;
+            this.dy = y;
+            this.dz = z + 0.5F;
+            return;
+        }
+        if (this.isSafe(world, x, y, z - 1)) {
+            mob.moveTo(x + 0.5F, y, z - 0.5F, yRot, xRot);
+            this.dx = x + 0.5F;
+            this.dy = y;
+            this.dz = z - 0.5F;
+            return;
+        }
+        if (this.isSafe(world, x, y, z + 1)) {
+            mob.moveTo(x + 0.5F, y, z + 1.5F, yRot, xRot);
+            this.dx = x + 0.5F;
+            this.dy = y + 1;
+            this.dz = z;
+            return;
+        }
+        mob.moveTo(x + 0.5F, y + 1, z + 0.5F, yRot, xRot);
+        this.dx = x + 0.5F;
+        this.dy = y + 1;
+        this.dz = z + 0.5F;
+    }
+
+    private boolean isSafe(World world, int x, int y, int z) {
+        return !world.isBlockNormalCube(x, y, z) && !world.isBlockNormalCube(x, y + 1, z);
     }
 
 }

--- a/src/main/java/teamport/aether/entity/monster/mimic/MobMimic.java
+++ b/src/main/java/teamport/aether/entity/monster/mimic/MobMimic.java
@@ -65,7 +65,7 @@ public class MobMimic extends MobMonster implements Enemy {
     }
 
     public int getMaxHealth() {
-        return 40;
+        return 80;
     }
 
     public void setLoot(List<ItemStack> loot){

--- a/src/main/java/teamport/aether/tile/TileEntityMimic.java
+++ b/src/main/java/teamport/aether/tile/TileEntityMimic.java
@@ -1,0 +1,14 @@
+package teamport.aether.tile;
+
+import net.minecraft.core.block.entity.TileEntityChest;
+import net.minecraft.core.item.ItemStack;
+
+import javax.annotation.Nullable;
+
+public class TileEntityMimic extends TileEntityChest {
+    // cant remove from mimic's inventory
+    @Override
+    public @Nullable ItemStack removeItem(int index, int takeAmount){
+        return null;
+    }
+}

--- a/src/main/java/teamport/aether/world/generate/feature/components/WorldFeatureComponent.java
+++ b/src/main/java/teamport/aether/world/generate/feature/components/WorldFeatureComponent.java
@@ -7,6 +7,7 @@ import net.minecraft.core.item.ItemStack;
 import net.minecraft.core.player.inventory.container.Container;
 import net.minecraft.core.util.helper.Direction;
 import net.minecraft.core.world.World;
+import teamport.aether.AetherMod;
 import teamport.aether.blocks.AetherBlocks;
 import teamport.aether.world.generate.feature.BlockPallet;
 
@@ -153,7 +154,7 @@ public class WorldFeatureComponent {
             inventory.setItem(index, itemStack);
         }
         if(emptyCount == quantity){
-            System.out.printf("EmptyChest! quantity:%d, x%d, y:%d, z:%d\n", quantity, wfb.x, wfb.y, wfb.z);
+            AetherMod.LOGGER.error("Generated empty chest quantity:{}, x:{}, y:{}, z:{}\n", quantity, wfb.x, wfb.y, wfb.z);
         }
     }
 

--- a/src/main/java/teamport/aether/world/generate/feature/components/WorldFeatureSilverMaze.java
+++ b/src/main/java/teamport/aether/world/generate/feature/components/WorldFeatureSilverMaze.java
@@ -87,7 +87,6 @@ public class WorldFeatureSilverMaze {
                 if (prev == index) index++;
                 if (index > 7) index = index % 7;
                 prev = index;
-                System.out.printf("stairs: from:%d, to:%d\n", LEVEL * 9 + index, (LEVEL + 1) * 9 + index);;
                 GRAPH.get(LEVEL * 9 + index).add((LEVEL + 1) * 9 + index);
                 GRAPH.get((LEVEL + 1) * 9 + index).add(LEVEL * 9 + index);
             }

--- a/src/main/resources/lang/aether/en_US/tile.lang
+++ b/src/main/resources/lang/aether/en_US/tile.lang
@@ -167,6 +167,7 @@ tile.aether.carved.hellfire.locked.desc=Unbreakable gold dungeon block.
 tile.aether.carved.hellfire.light.locked.name=Locked Light Hellfire Stone
 tile.aether.carved.hellfire.light.locked.desc=Unbreakable gold dungeon block that glows with an ethereal light.
 
+# hidden when btwaila is enabled
 tile.aether.chest.mimic.name=Trapped Chest
 tile.aether.chest.mimic.desc=Thank you dark souls.
 


### PR DESCRIPTION
Summary:

- hide mimic with btwaila loaded
- place mimic on a safe tile (might need adjustments)
- tile entity for mimic to prevent item from beeing removed from its inventory
- logging stuff