### PR TITLE
7.3 but better

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -202,7 +202,7 @@ tasks {
                 )
             )
         }
-        filesMatching("*.mixins.json") { expand(mapOf("java" to stringJavaVersion)) }
+        filesMatching("**/*.mixins.json") { expand(mapOf("java" to stringJavaVersion)) }
     }
     java {
         toolchain {

--- a/src/main/resources/compat/aether/waila/waila.mixins.json
+++ b/src/main/resources/compat/aether/waila/waila.mixins.json
@@ -4,7 +4,7 @@
     "minVersion": "0.5.0"
   },
   "package": "teamport.aether.compat.waila.mixins",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_${java}",
   "client": [
     "WallaceMixin"
   ]


### PR DESCRIPTION
This fixes the previous issue that required the java version to be hardcoded in `waila.mixins.json`.