### PR TITLE
Build Script Update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v5
       - name: setup jdk ${{ matrix.java }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-@file:Suppress("UnstableApiUsage")
 import com.smushytaco.lwjgl_gradle.Preset
 plugins {
     alias(libs.plugins.loom)
@@ -15,7 +14,6 @@ base.archivesName = modName
 group = modGroup.get()
 version = modVersion.get()
 loom {
-    noIntermediateMappings()
     customMinecraftMetadata.set("https://downloads.betterthanadventure.net/bta-client/${libs.versions.btaChannel.get()}/v${libs.versions.bta.get()}/manifest.json")
 }
 repositories {
@@ -55,22 +53,20 @@ lwjgl {
 }
 dependencies {
     minecraft("::${libs.versions.bta.get()}")
-    mappings(loom.layered {})
 
-    // https://piston-data.mojang.com/v1/objects/43db9b498cb67058d2e12d394e6507722e71bb45/client.jar
-    modImplementation("objects:client:43db9b498cb67058d2e12d394e6507722e71bb45")
-    modImplementation(libs.loader)
-    modImplementation(libs.halplibe)
-    modImplementation(libs.modMenu)
-    modImplementation(libs.legacyLwjgl)
+    compileOnly(libs.btwaila)
+    compileOnly(libs.commandly)
 
-    modImplementation(libs.dragonfly)
-    modImplementation(libs.catalyst.core)
-    modImplementation(libs.catalyst.effects)
-    modImplementation(libs.uselessNumerical.get().let { "${it.group}:${it.name}:${it.version}-${libs.versions.bta.get()}" })
+    runtimeOnly(libs.clientJar)
+    implementation(libs.loader)
+    implementation(libs.halplibe)
+    implementation(libs.modMenu)
+    implementation(libs.legacyLwjgl)
 
-    modCompileOnly(libs.btwaila)
-    modCompileOnly(libs.commandly)
+    implementation(libs.dragonfly)
+    implementation(libs.catalyst.core)
+    implementation(libs.catalyst.effects)
+    implementation(libs.uselessNumerical.get().let { "${it.group}:${it.name}:${it.version}-${libs.versions.bta.get()}" })
 
     implementation(libs.slf4jApi)
     implementation(libs.guava)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 ##########################################################################
 # Plugins
-# Check this on https://maven.thesignalumproject.net/#/infrastructure/fabric-loom/fabric-loom.gradle.plugin/
-loom = "1.13.0-bta"
+# Check this on https://github.com/FabricMC/fabric-loom/releases/latest/
+loom = "1.14-SNAPSHOT"
 # Check this on https://plugins.gradle.org/plugin/com.smushytaco.lwjgl3/
 lwjglPlugin = "1.0.0"
 ##########################################################################
@@ -18,11 +18,11 @@ bta = "7.3_04"
 # Options are release, prerelease, nightly, and misc.
 btaChannel = "release"
 # Check this on https://maven.thesignalumproject.net/#/infrastructure/net/fabricmc/fabric-loader/
-loader = "0.17.3-bta.8"
+loader = "0.18.1-bta.9"
 # Check this on https://github.com/Turnip-Labs/ModMenu/releases/latest/
-modMenu = "3.0.0"
+modMenu = "4.0.0"
 # Check this on https://github.com/Turnip-Labs/bta-halplibe/releases/latest/
-halplibe = "5.3.1"
+halplibe = "5.3.2"
 # Check this on https://github.com/Better-than-Adventure/legacy-lwjgl3/releases/latest/
 legacyLwjgl = "1.0.6"
 # Check this on https://maven.thesignalumproject.net/#/releases/sunsetsatellite/catalyst-core/
@@ -72,7 +72,9 @@ log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.re
 log4j-api12 = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commonsLang3" }
+# https://piston-data.mojang.com/v1/objects/43db9b498cb67058d2e12d394e6507722e71bb45/client.jar
+clientJar = { group = "objects", name = "client", version = "43db9b498cb67058d2e12d394e6507722e71bb45" }
 
 [plugins]
-loom = { id = "fabric-loom", version.ref = "loom" }
+loom = { id = "net.fabricmc.fabric-loom", version.ref = "loom" }
 lwjgl = { id = "com.smushytaco.lwjgl3", version.ref = "lwjglPlugin" }


### PR DESCRIPTION
1. Updated to use upstream loom (which now supports unobfuscated jars). modImplementation is now just implementation. modRuntimeOnly is now just runtimeOnly, modCompileOnly is now just compileOnly, etc.
2. Updated workflow action.
3. Updated dependencies (loader, halplibe, etc).