### PR TITLE
Portal Fix, DeathLoop Fix, RecipeNamespace Fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,8 @@ plugins {
 
 val lwjglNatives = resolveLwjglNatives()
 
-val modVersion = "${providers.gradleProperty("mod_version").get()}+${libs.versions.bta.get()}"
+val modVersion = "${providers.gradleProperty("mod_version").get()}"
+//val modVersion = "${providers.gradleProperty("mod_version").get()}+${libs.versions.bta.get()}"
 val modGroup: Provider<String> = providers.gradleProperty("mod_group")
 val modName: Provider<String> = providers.gradleProperty("mod_name")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.warning.mode = all
 org.gradle.configuration-cache = false
 ##########################################################################
 # Mod Properties
-mod_version = 1.1.0
+mod_version = 1.1.0-pre1
 mod_group = teamport
 mod_name = better-with-aether
 ##########################################################################

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.warning.mode = all
 org.gradle.configuration-cache = false
 ##########################################################################
 # Mod Properties
-mod_version = 1.1.0-pre1
+mod_version = 1.1.2-pre1
 mod_group = teamport
 mod_name = better-with-aether
 ##########################################################################

--- a/src/main/java/teamport/aether/AetherConfig.java
+++ b/src/main/java/teamport/aether/AetherConfig.java
@@ -58,7 +58,6 @@ public class AetherConfig {
                     .getFriendlyString()
                     .substring(0, 5);
 
-            if (version.endsWith(".0")) version = version.substring(0, 3);
             result = String.format(
                 "https://raw.githubusercontent.com/bta-team-port/better-with-aether/refs/tags/%s-%s/remoteAssets/",
                 version,

--- a/src/main/java/teamport/aether/AetherConfig.java
+++ b/src/main/java/teamport/aether/AetherConfig.java
@@ -51,7 +51,6 @@ public class AetherConfig {
             result = "https://raw.githubusercontent.com/bta-team-port/better-with-aether/refs/heads/7.3/remoteAssets/";
         } else {
             ModContainer modContainer = modContainerOpt.get();
-
             String version = modContainer
                     .getMetadata()
                     .getVersion()

--- a/src/main/java/teamport/aether/AetherMod.java
+++ b/src/main/java/teamport/aether/AetherMod.java
@@ -125,6 +125,7 @@ public class AetherMod implements ModInitializer {
         AetherBlocks.init();
         AetherItems.init();
         AetherWorldFeatures.init();
+        AetherDimension.init();
 
         registerNewTagForBlocks();
 
@@ -150,7 +151,7 @@ public class AetherMod implements ModInitializer {
     }
 
     public void afterDimensionInit(){
-        AetherDimension.init();
+        AetherDimension.register();
     }
 
     public void afterGameStart() {

--- a/src/main/java/teamport/aether/AetherMod.java
+++ b/src/main/java/teamport/aether/AetherMod.java
@@ -60,7 +60,8 @@ public class AetherMod implements ModInitializer {
     public static final String MOD_ID = HalpLibe.registerMod("aether", true);
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     public static final String VERSION_STRING = FabricLoader.getInstance().getModContainer(MOD_ID).get().getMetadata().getVersion().getFriendlyString();
-    public static final String STATE = "release";
+//    public static final String STATE = "release";
+    public static final String STATE = "pre1";
     public static I18n TRANSLATOR = null;
     public static MobFireflyCluster.FireflyColor SILVER;
 

--- a/src/main/java/teamport/aether/AetherMod.java
+++ b/src/main/java/teamport/aether/AetherMod.java
@@ -179,9 +179,9 @@ public class AetherMod implements ModInitializer {
     public static void registerNewRecipeTypes() {
         Registries.RECIPE_TYPES.register("aether:machine", RecipeEntryAetherMachine.class);
         Registries.RECIPE_TYPES.register("aether:incubator", RecipeEntryIncubator.class);
-        if (AetherConfig.INCLUDE_REPAIR_RECIPES) {
+//        if (AetherConfig.INCLUDE_REPAIR_RECIPES) {
             Registries.RECIPE_TYPES.register("aether:repair", RecipeEntryAetherMachine.class);
-        }
+//        }
     }
 
     public static void registerNewTagForBlocks() {

--- a/src/main/java/teamport/aether/AetherRemoteResourceDownloaderThread.java
+++ b/src/main/java/teamport/aether/AetherRemoteResourceDownloaderThread.java
@@ -3,10 +3,7 @@ package teamport.aether;
 import com.b100.utils.FileUtils;
 import com.b100.utils.StreamUtils;
 import com.b100.utils.StringUtils;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import net.fabricmc.api.EnvType;
@@ -19,6 +16,7 @@ import net.minecraft.core.net.CertificateHelper;
 import java.io.*;
 import java.math.BigInteger;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -69,14 +67,29 @@ public class AetherRemoteResourceDownloaderThread extends Thread {
     public void run() {
         JsonArray manifest;
 
+        String manifestURL = url + "manifest.json";
         try {
-            String manifestURL = url + "manifest.json";
-            manifest = JsonParser.parseString(StringUtils.getWebsiteContentAsString(manifestURL)).getAsJsonArray();
-            LOGGER.info("Manifest Downloaded");
-
-        } catch (Exception except) {
+            LOGGER.info("Fetching resource manifest from {}", manifestURL);
+            String content = StringUtils.getWebsiteContentAsString(manifestURL);
+            JsonElement jsonElement = JsonParser.parseString(content);
+            if (!jsonElement.isJsonArray()) {
+                this.state = State.ERROR;
+                LOGGER.error("Resource manifest does not contain a JSON array. URL: {}, Content: {}", manifestURL, content);
+                return;
+            }
+            manifest = jsonElement.getAsJsonArray();
+            LOGGER.info("Manifest downloaded successfully from {}", manifestURL);
+        } catch (JsonSyntaxException exception) {
             this.state = State.ERROR;
-            LOGGER.error("Failed to fetch resource manifest.");
+            LOGGER.error("Failed to parse resource manifest as JSON. URL: {}", manifestURL, exception);
+            return;
+        } catch (IllegalStateException exception) {
+            this.state = State.ERROR;
+            LOGGER.error("Resource manifest has an unexpected JSON structure. URL: {}", manifestURL, exception);
+            return;
+        } catch (Exception exception) {
+            this.state = State.ERROR;
+            LOGGER.error("Failed to fetch resource manifest from {}", manifestURL, exception);
             return;
         }
 

--- a/src/main/java/teamport/aether/block/AetherBlocks.java
+++ b/src/main/java/teamport/aether/block/AetherBlocks.java
@@ -235,7 +235,7 @@ public final class AetherBlocks {
     public static void initializeBlocks() {
 
         PORTAL_AETHER = register("portal.aether", blockKey("portal_aether"), blockID("PORTAL_AETHER"),
-            b -> new BlockLogicPortalAether(b, AetherDimension.getAether(), Blocks.GLOWSTONE, Blocks.FLUID_WATER_FLOWING))
+            b -> new BlockLogicPortalAether(b, AetherDimension.AETHER, Blocks.GLOWSTONE, Blocks.FLUID_WATER_FLOWING))
             .withSound(BlockSounds.GLASS)
             .withHardness(-1.0F)
             .withLightEmission(15)

--- a/src/main/java/teamport/aether/effect/DeathCauseEffects.java
+++ b/src/main/java/teamport/aether/effect/DeathCauseEffects.java
@@ -45,7 +45,7 @@ public class DeathCauseEffects extends DeathCause {
 
     @Override
     public void serializeAdditional(CompoundTag tag) {
-        super.serialize(tag);
+        super.serializeAdditional(tag);
         tag.putString("aether:effectsID", this.effectsID);
         if(this.hasSecondary) {
             tag.putString("aether:poison_keyShard", this.keyShard);
@@ -54,7 +54,7 @@ public class DeathCauseEffects extends DeathCause {
 
     @Override
     public void deserializeAdditional(CompoundTag tag) {
-        super.deserialize(tag);
+        super.deserializeAdditional(tag);
         this.effectsID = tag.getString("aether:effectsID");
         this.hasSecondary = tag.containsKey("aether:poison_keyShard");
         if(this.hasSecondary){

--- a/src/main/java/teamport/aether/entity/DeathCauseKeyed.java
+++ b/src/main/java/teamport/aether/entity/DeathCauseKeyed.java
@@ -1,0 +1,44 @@
+package teamport.aether.entity;
+
+import com.mojang.nbt.tags.CompoundTag;
+import net.minecraft.core.entity.Mob;
+import turniplabs.halplibe.util.deathcause.DeathCause;
+
+/**
+ * @deprecated Will be deprecated in the next HalpLibe release (6.2.1).
+ */
+@Deprecated(forRemoval = true)
+public class DeathCauseKeyed extends DeathCause {
+    String keyShard = "generic";
+
+    public DeathCauseKeyed(){
+        super();
+    }
+
+    public DeathCauseKeyed(Mob victim){
+        super(victim);
+    }
+
+    public DeathCauseKeyed(Mob victim, String keyShard){
+        super(victim);
+        this.keyShard = keyShard;
+
+    }
+
+    @Override
+    protected String getTranslationKeyShard() {
+        return this.keyShard;
+    }
+
+    @Override
+    protected void serializeAdditional(CompoundTag tag) {
+        tag.putString("halplibe:key_shard", this.keyShard);
+    }
+
+    @Override
+    protected void deserializeAdditional(CompoundTag tag) {
+        if(tag.containsKey("halplibe:key_shard")){
+            this.keyShard = tag.getString("halplibe:key_shard");
+        }
+    }
+}

--- a/src/main/java/teamport/aether/entity/boss/DeathCauseBoss.java
+++ b/src/main/java/teamport/aether/entity/boss/DeathCauseBoss.java
@@ -32,6 +32,7 @@ public class DeathCauseBoss extends DeathCauseKilledBy {
 
     @Override
     public void serializeAdditional(CompoundTag tag) {
+        super.serializeAdditional(tag);
         tag.putString("aether:bossName", this.bossName);
         tag.putString("aether:bossTitle", this.bossTile);
         tag.putByte("aether:bossColor", this.bossColor);
@@ -40,6 +41,7 @@ public class DeathCauseBoss extends DeathCauseKilledBy {
 
     @Override
     public void deserializeAdditional(CompoundTag tag) {
+        super.deserializeAdditional(tag);
         this.bossName = tag.getString("aether:bossName");
         this.bossTile = tag.getString("aether:bossTitle");
         this.bossColor = tag.getByte("aether:bossColor");

--- a/src/main/java/teamport/aether/entity/monster/swet/DeathCauseKilledSecondary.java
+++ b/src/main/java/teamport/aether/entity/monster/swet/DeathCauseKilledSecondary.java
@@ -26,7 +26,7 @@ public class DeathCauseKilledSecondary extends DeathCauseKilledBy {
 
     @Override
     public void serializeAdditional(CompoundTag tag) {
-        super.serialize(tag);
+        super.serializeAdditional(tag);
         if(this.hasSecondary) {
             tag.putString("aether:second_keyShard", this.keyShard);
         }
@@ -34,7 +34,7 @@ public class DeathCauseKilledSecondary extends DeathCauseKilledBy {
 
     @Override
     public void deserializeAdditional(CompoundTag tag) {
-        super.deserialize(tag);
+        super.deserializeAdditional(tag);
         this.hasSecondary = tag.containsKey("aether:second_keyShard");
         if(this.hasSecondary){
             this.keyShard = tag.getString("aether:second_keyShard");

--- a/src/main/java/teamport/aether/entity/player/PlayerUtil.java
+++ b/src/main/java/teamport/aether/entity/player/PlayerUtil.java
@@ -23,6 +23,7 @@ import sunsetsatellite.catalyst.effects.api.effect.IHasEffects;
 import teamport.aether.ducks.IContainerInventoryAether;
 import teamport.aether.effect.AetherEffects;
 import teamport.aether.effect.DeathCauseEffects;
+import teamport.aether.entity.DeathCauseKeyed;
 import teamport.aether.entity.PreVehicle;
 import teamport.aether.entity.boss.DeathCauseBoss;
 import teamport.aether.entity.boss.EnemyBoss;
@@ -36,7 +37,6 @@ import teamport.aether.item.accessory.gloves.ItemGloves;
 import teamport.aether.item.accessory.pendant.ItemIcePendant;
 import turniplabs.halplibe.helper.EnvironmentHelper;
 import turniplabs.halplibe.util.deathcause.DeathCause;
-import turniplabs.halplibe.util.deathcause.vanilla.DeathCauseGeneric;
 import turniplabs.halplibe.util.deathcause.vanilla.DeathCauseKilledBy;
 import turniplabs.halplibe.util.deathcause.vanilla.DeathCauseProjectile;
 
@@ -295,12 +295,12 @@ public class PlayerUtil {
         if ((pendant1 != null && pendant1.getItem() instanceof ItemIcePendant)
             || (pendant2 != null && pendant2.getItem() instanceof ItemIcePendant)
         ) {
+            TilePos tilePos = new TilePos(victim);
+            Block<?> block = victim.world.getBlockType(tilePos.down());
+            if (block == Blocks.OBSIDIAN || block == Blocks.ICE) {
+                return new DeathCauseKeyed(victim, "ice_pendant");
+            }
             return null;
-        }
-        TilePos tilePos = new TilePos(victim);
-        Block<?> block = victim.world.getBlockType(tilePos);
-        if (block == Blocks.OBSIDIAN || block == Blocks.ICE) {
-            return new DeathCauseGeneric(victim, "ice_pendant");
         }
         return null;
     }

--- a/src/main/java/teamport/aether/item/accessory/pendant/ItemIcePendant.java
+++ b/src/main/java/teamport/aether/item/accessory/pendant/ItemIcePendant.java
@@ -8,7 +8,9 @@ import net.minecraft.core.entity.player.Player;
 import net.minecraft.core.item.ItemStack;
 import net.minecraft.core.item.material.ArmorMaterial;
 import net.minecraft.core.util.helper.MathHelper;
+import net.minecraft.core.util.phys.HitResult;
 import net.minecraft.core.world.World;
+import org.joml.Vector3d;
 import org.jspecify.annotations.NonNull;
 import teamport.aether.entity.player.PlayerUtil;
 
@@ -51,25 +53,29 @@ public class ItemIcePendant extends ItemPendant {
             return;
         }
 
-        int playerX = MathHelper.floor(player.x);
-        int playerY = MathHelper.floor(player.y - 0.5);
-        int playerZ = MathHelper.floor(player.z);
+        Vector3d playerPos = new Vector3d(player.x, player.y - 1, player.z);
+        Vector3d playerNextPos = new Vector3d(player.x + player.xd, player.y - 1 + player.yd - 1, player.z + player.zd);
+        HitResult hits = world.checkBlockCollisionBetweenPoints(playerPos, playerNextPos, true);
+        if (!(hits instanceof HitResult.Tile)) return;
+        int x = MathHelper.ceil(hits.location.x());
+        int y = MathHelper.ceil(hits.location.y());
+        int z = MathHelper.ceil(hits.location.z());
 
         int proc = 0;
         int radius = pendantCount;
 
         for (int xOffset = -radius; xOffset <= radius; xOffset++) {
             for (int zOffset = -radius; zOffset <= radius; zOffset++) {
-                int xPos = playerX + xOffset;
-                int zPos = playerZ + zOffset;
+                int xPos = x + xOffset;
+                int zPos = z + zOffset;
 
-                Material material = world.getBlockMaterial(xPos, playerY, zPos);
+                Material material = world.getBlockMaterial(xPos, y, zPos);
                 if (material == Materials.WATER) {
                     proc++;
-                    world.setBlockWithNotify(xPos, playerY, zPos, Blocks.ICE.id());
+                    world.setBlockWithNotify(xPos, y, zPos, Blocks.ICE.id());
                 } else if (material == Materials.LAVA) {
                     proc++;
-                    world.setBlockWithNotify(xPos, playerY, zPos, Blocks.OBSIDIAN.id());
+                    world.setBlockWithNotify(xPos, y, zPos, Blocks.OBSIDIAN.id());
                 }
             }
         }

--- a/src/main/java/teamport/aether/mixin/dimension/ParachuteMixin.java
+++ b/src/main/java/teamport/aether/mixin/dimension/ParachuteMixin.java
@@ -1,7 +1,5 @@
 package teamport.aether.mixin.dimension;
 
-import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.minecraft.core.entity.EntityItem;
 import net.minecraft.core.entity.Mob;
 import net.minecraft.core.entity.player.Player;
@@ -11,6 +9,9 @@ import net.minecraft.core.world.World;
 import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import teamport.aether.item.AetherItems;
 import teamport.aether.world.AetherDimension;
 import turniplabs.halplibe.helper.EnvironmentHelper;
@@ -31,8 +32,8 @@ public abstract class ParachuteMixin extends Mob {
         super(world);
     }
 
-    @WrapMethod(method = "tick")
-    public void grantChute(Operation<Void> original) {
+    @Inject(method = "tick", at = @At("HEAD"))
+    public void grantChute(CallbackInfo ci) {
         if (this.world.dimension.id == AetherDimension.getAether().id && !EnvironmentHelper.isMultiplayerClient() && AetherDimension.canGetParachute(uuid)) {
             if (!this.gamemode.hasInvulnerablePlayer()) {
                 EntityItem chute = new EntityItem(world, x, y, z, new ItemStack(AetherItems.PARACHUTE_CLOUD, 1));
@@ -41,7 +42,5 @@ public abstract class ParachuteMixin extends Mob {
 
             AetherDimension.setParachuteReceived(uuid);
         }
-
-        original.call();
     }
 }

--- a/src/main/java/teamport/aether/world/AetherDimension.java
+++ b/src/main/java/teamport/aether/world/AetherDimension.java
@@ -54,13 +54,26 @@ public class AetherDimension {
     private static final HashMap<UUID, Boolean> HAS_RECEIVED_PARACHUTE_MAP = new HashMap<>();
     private static final HashMap<UUID, CompoundTag> HAS_BUNNY_MAP = new HashMap<>();
     // inits
-    private static Dimension AETHER;
+    public static final Dimension AETHER;
     private static boolean hasInit = false;
+
+    static {
+        AETHER = new Dimension("aether", Dimension.OVERWORLD, 1.0f, AetherBlocks.PORTAL_AETHER, AetherWorldTypes.AETHER_DEFAULT);
+    }
 
     private AetherDimension() {
     }
 
     public static void init() {
+        /**
+         * ⚠️ Very important do not delete this! Do not think even of doing this. No I heard you thinking it stop it get some help.
+         * Dimension need to be created earlier as it is required to be not null for portal.
+         * The games does not check it! Registration however need to be done much later cause otherwise it will cause issues for
+         * loading worlds!
+         */
+    }
+
+    public static void register(){
         if (!hasInit) {
             hasInit = true;
             initializeDimension();
@@ -72,8 +85,7 @@ public class AetherDimension {
         AetherWorldTypes.init();
         BiomeProviderAether.init();
         WorldTypeGroups.GROUPS.size();
-        AETHER = new Dimension("aether", Dimension.OVERWORLD, 1.0f, AetherBlocks.PORTAL_AETHER, AetherWorldTypes.AETHER_DEFAULT);
-        Dimension.registerDimension(AETHER_DIMENSION_ID, AETHER);
+        Dimension.registerDimension(AETHER_DIMENSION_ID, AETHER); // registration need to be happening later but init earlier
         AetherWorldTypes.addToWorldTypeGroups(AETHER);
         AetherDimension.initDimensionBlackList();
     }

--- a/src/main/java/teamport/aether/world/feature/dungeon/silver/WorldFeatureAetherSilverDungeon.java
+++ b/src/main/java/teamport/aether/world/feature/dungeon/silver/WorldFeatureAetherSilverDungeon.java
@@ -4,11 +4,11 @@ import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectObjectMutablePair;
 import net.minecraft.core.WeightedRandomBag;
 import net.minecraft.core.WeightedRandomLootObject;
-import net.minecraft.core.block.BlockLogicRotatable;
-import net.minecraft.core.block.Blocks;
+import net.minecraft.core.block.*;
 import net.minecraft.core.block.material.Material;
 import net.minecraft.core.block.material.Materials;
 import net.minecraft.core.item.ItemStack;
+import net.minecraft.core.lang.I18n;
 import net.minecraft.core.util.helper.Direction;
 import net.minecraft.core.util.helper.MathHelper;
 import net.minecraft.core.world.World;
@@ -183,11 +183,13 @@ public class WorldFeatureAetherSilverDungeon extends WorldFeatureMap<DungeonLogi
         for (WorldFeaturePoint point : clear.getBlockList()) {
 
             point.rotateYAroundPivot(theDungeonAnchor, this.direction);
-            Material blockMaterial = world.getBlockMaterial(point.getX(), point.getY(), point.getZ());
-            BlockLogicCloudBase blockLogic = world.getBlockLogic(point.getX(), point.getY(), point.getZ(), BlockLogicCloudBase.class);
+            Block<?> block = world.getBlockType(new TilePos(point.getX(), point.getY(), point.getZ()));
+            int data = world.getBlockData(new TilePos(point.getX(), point.getY(), point.getZ()));
+            Material blockMaterial = block.getMaterial();
+            BlockLogic blockLogic = block.getLogic();
 
-            if (blockMaterial != Materials.AIR && blockLogic == null) {
-                AetherGlobals.LOGGER.info("Could not place a silver dungeon at {},{},{}, with blockMaterial {}", x, y, z, blockMaterial.getClass());
+            if (blockMaterial != Materials.AIR && !(blockLogic instanceof BlockLogicAir)) {
+                AetherGlobals.LOGGER.info("Could not place a silver dungeon at {},{},{}, because of block {}", x, y, z, I18n.getInstance().translateKey(blockLogic.getLanguageKey(data) + ".name"));
                 return false;
             }
         }


### PR DESCRIPTION
General server client relation ship improvements:
- Dimension is now initialized staticly to allow Aether Portal to connect corrently to the aether rather than crashing player.
- AetherDeatherCauses were accidently calling `super::seriliaze` and `super::deserialize` instead of `super::seriliazeAdditional` and `super::deserializeAdditional`, this would crash players sending the message.
- Sajmon accidently guarded the `aether:repair`, this resulted in the client beeing unaware of the recipe type crashing on log into the server. Removed the guard.
